### PR TITLE
fix(waydroid-script): add python build format

### DIFF
--- a/pkgs/waydroid-script/default.nix
+++ b/pkgs/waydroid-script/default.nix
@@ -10,6 +10,7 @@
   lzip,
   util-linux,
   nix-update-script,
+  setuptools,
 }:
 let
   pname = "waydroid-script";
@@ -42,6 +43,9 @@ buildPythonApplication rec {
     lzip
     util-linux
   ];
+
+  pyproject = true;
+  build-system = [ setuptools ];
 
   postPatch =
     let


### PR DESCRIPTION
Due to changes within Nix, waydroid-script no longer builds with the error 
```
error: waydroid-script-0-unstable-2024-01-20 does not configure a `format`. To build with setuptools as before, set `pyproject = true` and `build-system = [ setuptools ]`.`
```

This PR fixes this issue.
